### PR TITLE
Update yaml and readme to match current CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.classpath
+.gradle
+.settings
+.project
+.vscode
+.wercker
+bin/
+build/

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ This application uses the `openjdk` container obtained from the [Docker Hub](htt
 Clone this repo and cd into the directory:
 
 ```
-> git clone git@github.com:wercker/getting-started-java.git
-> cd getting-started-java
+git clone https://github.com/wercker/getting-started-java.git
+cd getting-started-java
 ```
 
 then build using:
 
 ```
-> wercker build
+wercker build
 ```
 
 ## Run
 To run the application, simply execute:
 
 ```
-> wercker dev --expose-ports
+wercker dev --expose-ports
 ```
 
 Now point your browser at `http://localhost:8080` to see:
@@ -32,5 +32,5 @@ Hello World!
 ```
 
 ---
-Sign up for wercker [here](http://wercker.com)
-Learn more on our [dev center](http://devcenter.wercker.com)
+Sign up for wercker: http://www.wercker.com
+Learn more at: http://devcenter.wercker.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# getting-started-java
-Java getting started application for wercker
+getting-started-java
+======================
+
+A sample application in Java for wercker.
+
+This application uses the `openjdk` container obtained from the [Docker Hub](https://registry.hub.docker.com/_/openjdk/)
+
+## Setup & Build
+Clone this repo and cd into the directory:
+
+```
+> git clone git@github.com:wercker/getting-started-java.git
+> cd getting-started-java
+```
+
+then build using:
+
+```
+> wercker build
+```
+
+## Run
+To run the application, simply execute:
+
+```
+> wercker dev --expose-ports
+```
+
+Now point your browser at `http://localhost:8080` to see:
+```
+Hello World!
+```
+
+---
+Sign up for wercker [here](http://wercker.com)
+Learn more on our [dev center](http://devcenter.wercker.com)

--- a/src/main/java/demo/Hello.java
+++ b/src/main/java/demo/Hello.java
@@ -1,8 +1,7 @@
-package com.example;
+package demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,7 +11,7 @@ public class Hello {
 
 	@RequestMapping("/")
 	public String home() {
-		return "Hello World";
+		return "Hello World!";
 	}
 
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,8 @@
 # docker box definition
-box: java
+box:
+  id: openjdk
+  ports:
+    - "8080"
 
 # defining the dev pipeline
 dev:
@@ -8,6 +11,14 @@ dev:
       name: gradle bootRun
       code: |
         ./gradlew bootRun
+
+    ### REPLACE the above script step with this internal/watch step to enable 
+    ### dynamic rebuilding/reloading of the container in response to file changes.
+    #
+    # - internal/watch:
+    #     code: |
+    #       ./gradlew bootRun
+    #     reload: true
 
 # Build definition
 build:


### PR DESCRIPTION
Primarily brings the wercker.yml in line with the current behaviour of the CLI, explicitly declaring ports in the .yml, and also switches the box from java to openjdk.